### PR TITLE
fix: Transcript entity fixed #34

### DIFF
--- a/src/main/java/com/springdemo/capstoneproject1/model/Transcript.java
+++ b/src/main/java/com/springdemo/capstoneproject1/model/Transcript.java
@@ -14,7 +14,7 @@ public class Transcript {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer transcriptId;
 
-    private Double startTime;
+    private String startTime;
 
     @Column(columnDefinition = "TEXT")
     private String content;

--- a/src/main/java/com/springdemo/capstoneproject1/service/TranscriptService.java
+++ b/src/main/java/com/springdemo/capstoneproject1/service/TranscriptService.java
@@ -63,10 +63,8 @@ public class TranscriptService {
             String timePart = line.substring(1, line.indexOf("]"));
             String contentPart = line.substring(line.indexOf("]") + 1).trim();
 
-            double startTimeSeconds = convertTimeToSeconds(timePart);
-
             Transcript t = new Transcript();
-            t.setStartTime(startTimeSeconds);
+            t.setStartTime(timePart);
             t.setContent(contentPart);
             t.setChapter(chapter);
             t.setCreatedAt(LocalDateTime.now());
@@ -118,10 +116,8 @@ public class TranscriptService {
             String timePart = raw.substring(1, raw.indexOf("]"));
             // "00:00:02,610"
 
-            double seconds = convertTimeToSeconds(timePart);
-
             Transcript t = new Transcript();
-            t.setStartTime(seconds);
+            t.setStartTime(timePart);
             t.setContent(item.getContent());
             t.setChapter(chapter);
             t.setCreatedAt(LocalDateTime.now());


### PR DESCRIPTION
## 🔀 Pull Request 요약

- 관련 브랜치: `fix/#34-API-startTime-fix`
- 작업 내용 요약:
> Entity 내부에 startTime이 double이었던 점을 확인 -> string으로 고침
## ✅ 작업 완료 내역 체크리스트

- [ ] 기능 동작 확인
- [ ] 테스트 코드 포함 (필요시)
- [ ] 문서 및 주석 정리
- [ ] 코드 컨벤션 준수

## 🔁 관련 이슈

- Closes #34 

## 🙋‍♂️ 리뷰어에게 한 마디
