### PR TITLE
fix: transcriptDTO changed as well (from double to String) #34

### DIFF
--- a/src/main/java/com/springdemo/capstoneproject1/dto/TranscriptDTO.java
+++ b/src/main/java/com/springdemo/capstoneproject1/dto/TranscriptDTO.java
@@ -8,7 +8,7 @@ import java.time.LocalDateTime;
 public class TranscriptDTO {
 
     private Integer transcriptId;
-    private Double startTime;
+    private String startTime;
     private String content;
     private LocalDateTime createdAt;
 


### PR DESCRIPTION
## 🔀 Pull Request 요약

- 관련 브랜치: `fix/#34-API-startTime-fix`
- 작업 내용 요약:
- TranscriptDTO에서도 startTime을 double type에서 String으로 수정

## ✅ 작업 완료 내역 체크리스트

- [ ] 기능 동작 확인
- [ ] 테스트 코드 포함 (필요시)
- [ ] 문서 및 주석 정리
- [ ] 코드 컨벤션 준수

## 🔁 관련 이슈

- Closes #34

## 🙋‍♂️ 리뷰어에게 한 마디
