### PR TITLE
fix: now neglects comma and afterwards in timestamp #48

### DIFF
--- a/src/main/java/com/springdemo/capstoneproject1/service/HistoryService.java
+++ b/src/main/java/com/springdemo/capstoneproject1/service/HistoryService.java
@@ -47,11 +47,25 @@ public class HistoryService {
     }
 
     private int convertToSeconds(String ts) {
+
+        if (ts == null || ts.isBlank()) return 0;
+
+        // milliseconds 제거
+        if (ts.contains(",")) ts = ts.split(",")[0];
+        if (ts.contains(".")) ts = ts.split("\\.")[0];
+
         String[] p = ts.split(":");
-        return Integer.parseInt(p[0]) * 3600 +
-                Integer.parseInt(p[1]) * 60 +
-                Integer.parseInt(p[2]);
+        if (p.length != 3) return 0;
+
+        try {
+            return Integer.parseInt(p[0]) * 3600 +
+                    Integer.parseInt(p[1]) * 60 +
+                    Integer.parseInt(p[2]);
+        } catch (Exception e) {
+            return 0;
+        }
     }
+
 
     public List<History> getAllHistory() {
         return historyRepository.findAll(Sort.by(Sort.Direction.DESC, "createdAt"));


### PR DESCRIPTION
## 🔀 Pull Request 요약

- 관련 브랜치: `feat/#48-API-ocr-overlay`
- 작업 내용 요약:
> HistoryService에서 timestamp에서 , 뒤를 버림

## ✅ 작업 완료 내역 체크리스트

- [ ] 기능 동작 확인
- [ ] 테스트 코드 포함 (필요시)
- [ ] 문서 및 주석 정리
- [ ] 코드 컨벤션 준수

## 🔁 관련 이슈

- Closes #48

## 🙋‍♂️ 리뷰어에게 한 마디
