### PR TITLE
fix: fixed timezone setting in application.yml and edited embedding r…

### DIFF
--- a/src/main/java/com/springdemo/capstoneproject1/controller/EmbeddingController.java
+++ b/src/main/java/com/springdemo/capstoneproject1/controller/EmbeddingController.java
@@ -7,6 +7,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 
+import java.io.InputStream;
+
 @RestController
 @RequestMapping("/api/embeddings")
 @RequiredArgsConstructor
@@ -21,10 +23,10 @@ public class EmbeddingController {
         return "Metadata saved";
     }
 
-    /** 2) NPY 저장 */
+    /** 2) NPY 저장 (스트리밍 방식으로 변경) */
     @PostMapping(value = "/upload-npy", consumes = MediaType.APPLICATION_OCTET_STREAM_VALUE)
-    public String uploadNpy(@RequestBody byte[] npy) throws Exception {
-        embeddingService.saveNpy(npy);
+    public String uploadNpy(InputStream inputStream) throws Exception {
+        embeddingService.saveNpyStream(inputStream);
         return "npy saved";
     }
 

--- a/src/main/java/com/springdemo/capstoneproject1/service/EmbeddingService.java
+++ b/src/main/java/com/springdemo/capstoneproject1/service/EmbeddingService.java
@@ -7,6 +7,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Base64;
@@ -28,15 +31,27 @@ public class EmbeddingService {
         objectMapper.writeValue(new File(META_JSON), req);
     }
 
-    public void saveNpy(byte[] npyBytes) throws Exception {
-        Files.write(Paths.get(EMBEDDING_NPY), npyBytes);
+//    public void saveNpy(byte[] npyBytes) throws Exception {
+//        Files.write(Paths.get(EMBEDDING_NPY), npyBytes);
+//    }
+
+    /** NPY 파일 스트리밍 방식으로 저장 (메모리 폭발 방지) */
+    public void saveNpyStream(InputStream inputStream) throws Exception {
+        File dir = new File(BASE_PATH);
+        if (!dir.exists()) dir.mkdirs();
+
+        File targetFile = new File(EMBEDDING_NPY);
+
+        try (OutputStream out = new FileOutputStream(targetFile)) {
+            inputStream.transferTo(out);  // 스트리밍 저장
+        }
     }
 
-    // NPY → double[][] 변환
-    private double[][] loadNpyAsDoubleArray() throws Exception {
-        byte[] bytes = Files.readAllBytes(Paths.get(EMBEDDING_NPY));
-        return npyToDoubleArray(bytes);
-    }
+//    // NPY → double[][] 변환
+//    private double[][] loadNpyAsDoubleArray() throws Exception {
+//        byte[] bytes = Files.readAllBytes(Paths.get(EMBEDDING_NPY));
+//        return npyToDoubleArray(bytes);
+//    }
 
     /** 최소 구현: numpy npy to double[][] (float32 assumed) */
     private double[][] npyToDoubleArray(byte[] npyBytes) {
@@ -104,4 +119,6 @@ public class EmbeddingService {
             throw new RuntimeException("Failed to delete embeddings.npy", e);
         }
     }
+
+
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,12 @@ spring:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
+  servlet:
+    multipart:
+      max-file-size: 500MB
+      max-request-size: 500MB
+  jackson:
+    time-zone: Asia/Seoul
 
   jpa:
     hibernate:
@@ -14,10 +20,14 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        jdbc:
+          time_zone: Asia/Seoul
     database-platform: org.hibernate.dialect.PostgreSQLDialect
 
 server:
   port: 8080
+  tomcat:
+    max-swallow-size: 500MB
 
 springdoc:
   api-docs:


### PR DESCRIPTION
…elated controllers so it's not out of heap memory #57

## 🔀 Pull Request 요약

- 관련 브랜치: `fix/#57-timezone-and-embedding`
- 작업 내용 요약:
> Timezone 관련 내용 수정 (application.yml에서 Asia/Seoul로 Time zone setting 추가)
> Embedding관련 endpoint들을 수행시키면 AWS 서버에서 out of heap memory 이슈를 발견. 수정.

## ✅ 작업 완료 내역 체크리스트

- [ ] 기능 동작 확인
- [ ] 테스트 코드 포함 (필요시)
- [ ] 문서 및 주석 정리
- [ ] 코드 컨벤션 준수

## 🔁 관련 이슈

- Closes #57

## 🙋‍♂️ 리뷰어에게 한 마디
