### PR TITLE
feat: new endpoint added for finding transcript by chapter #72

### DIFF
--- a/src/main/java/com/springdemo/capstoneproject1/controller/TranscriptController.java
+++ b/src/main/java/com/springdemo/capstoneproject1/controller/TranscriptController.java
@@ -39,6 +39,25 @@ public class TranscriptController {
                 .collect(Collectors.toList());
     }
 
+    /** Chapter ID 기준 Transcript 조회 */
+    @GetMapping("/chapter/{chapterId}")
+    public List<TranscriptDTO> getByChapterId(@PathVariable Integer chapterId) {
+
+        return transcriptService.findByChapterId(chapterId)
+                .stream()
+                .map(t -> {
+                    TranscriptDTO dto = new TranscriptDTO();
+                    dto.setTranscriptId(t.getTranscriptId());
+                    dto.setStartTime(t.getStartTime());
+                    dto.setContent(t.getContent());
+                    dto.setCreatedAt(t.getCreatedAt());
+                    dto.setChapterId(t.getChapter().getChapterId());
+                    dto.setLectureId(t.getChapter().getLecture().getLectureId());
+                    return dto;
+                })
+                .collect(Collectors.toList());
+    }
+
     /** 단일 Transcript 조회 */
     @GetMapping("/{id}")
     public TranscriptDTO getById(@PathVariable Integer id) {

--- a/src/main/java/com/springdemo/capstoneproject1/service/TranscriptService.java
+++ b/src/main/java/com/springdemo/capstoneproject1/service/TranscriptService.java
@@ -145,4 +145,8 @@ public class TranscriptService {
                 });
     }
 
+    public List<Transcript> findByChapterId(Integer chapterId) {
+        return transcriptRepository.findByChapter_ChapterId(chapterId);
+    }
+
 }


### PR DESCRIPTION
## 🔀 Pull Request 요약

- 관련 브랜치: `feat/#72-API-transcript-by-chapter`
- 작업 내용 요약:
- 새로운 endpoint 추가; transcript를 챕터별 (강의별)로 찾아볼수있게함

## ✅ 작업 완료 내역 체크리스트

- [ ] 기능 동작 확인
- [ ] 테스트 코드 포함 (필요시)
- [ ] 문서 및 주석 정리
- [ ] 코드 컨벤션 준수

## 🔁 관련 이슈

- Closes #72

## 🙋‍♂️ 리뷰어에게 한 마디
